### PR TITLE
Allow versioning by not forcing absolute path for graph requests

### DIFF
--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -57,7 +57,7 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= access_token.get('/me', info_options).parsed || {}
+        @raw_info ||= access_token.get('me', info_options).parsed || {}
       end
 
       def info_options

--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -187,7 +187,8 @@ module OmniAuth
 
       def image_url(uid, options)
         uri_class = options[:secure_image_url] ? URI::HTTPS : URI::HTTP
-        url = uri_class.build({:host => 'graph.facebook.com', :path => "/#{uid}/picture"})
+        site_uri = URI.parse(client.site)
+        url = uri_class.build({:host => site_uri.host, :path => "#{site_uri.path}/#{uid}/picture"})
 
         query = if options[:image_size].is_a?(String)
           { :type => options[:image_size] }

--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -16,7 +16,7 @@ module OmniAuth
       option :client_options, {
         :site => 'https://graph.facebook.com',
         :authorize_url => "https://www.facebook.com/dialog/oauth",
-        :token_url => '/oauth/access_token'
+        :token_url => 'oauth/access_token'
       }
 
       option :token_params, {

--- a/test/test.rb
+++ b/test/test.rb
@@ -104,6 +104,13 @@ class InfoTest < StrategyTestCase
     assert_equal 'https://graph.facebook.com/321/picture', strategy.info['image']
   end
 
+  test 'returns the image_url based of the client site' do
+    @options = { :secure_image_url => true, :client_options => {:site => "https://blah.facebook.com/v2.2"}}
+    raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
+    strategy.stubs(:raw_info).returns(raw_info)
+    assert_equal 'https://blah.facebook.com/v2.2/321/picture', strategy.info['image']
+  end
+
   test 'returns the image with size specified in the `image_size` option' do
     @options = { :image_size => 'normal' }
     raw_info = { 'name' => 'Fred Smith', 'id' => '321' }

--- a/test/test.rb
+++ b/test/test.rb
@@ -17,7 +17,7 @@ class ClientTest < StrategyTestCase
   end
 
   test 'has correct token url' do
-    assert_equal '/oauth/access_token', strategy.client.options[:token_url]
+    assert_equal 'oauth/access_token', strategy.client.options[:token_url]
   end
 end
 

--- a/test/test.rb
+++ b/test/test.rb
@@ -250,7 +250,7 @@ class RawInfoTest < StrategyTestCase
     strategy.stubs(:appsecret_proof).returns(@appsecret_proof)
     strategy.stubs(:access_token).returns(@access_token)
     params = {:params => @options}
-    @access_token.expects(:get).with('/me', params).returns(stub_everything('OAuth2::Response'))
+    @access_token.expects(:get).with('me', params).returns(stub_everything('OAuth2::Response'))
     strategy.raw_info
   end
 
@@ -259,7 +259,7 @@ class RawInfoTest < StrategyTestCase
     strategy.stubs(:access_token).returns(@access_token)
     strategy.stubs(:appsecret_proof).returns(@appsecret_proof)
     params = {:params => @options}
-    @access_token.expects(:get).with('/me', params).returns(stub_everything('OAuth2::Response'))
+    @access_token.expects(:get).with('me', params).returns(stub_everything('OAuth2::Response'))
     strategy.raw_info
   end
 
@@ -268,7 +268,7 @@ class RawInfoTest < StrategyTestCase
     strategy.stubs(:access_token).returns(@access_token)
     strategy.stubs(:appsecret_proof).returns(@appsecret_proof)
     params = {:params => {:appsecret_proof => @appsecret_proof, :fields => 'about'}}
-    @access_token.expects(:get).with('/me', params).returns(stub_everything('OAuth2::Response'))
+    @access_token.expects(:get).with('me', params).returns(stub_everything('OAuth2::Response'))
     strategy.raw_info
   end
 
@@ -281,7 +281,7 @@ class RawInfoTest < StrategyTestCase
     raw_response.stubs(:headers).returns({'Content-Type' => 'application/json' })
     oauth2_response = OAuth2::Response.new(raw_response)
     params = {:params => @options}
-    @access_token.stubs(:get).with('/me', params).returns(oauth2_response)
+    @access_token.stubs(:get).with('me', params).returns(oauth2_response)
     assert_kind_of Hash, strategy.raw_info
     assert_equal 'thar', strategy.raw_info['ohai']
   end
@@ -291,7 +291,7 @@ class RawInfoTest < StrategyTestCase
     strategy.stubs(:appsecret_proof).returns(@appsecret_proof)
     oauth2_response = stub('OAuth2::Response', :parsed => false)
     params = {:params => @options}
-    @access_token.stubs(:get).with('/me', params).returns(oauth2_response)
+    @access_token.stubs(:get).with('me', params).returns(oauth2_response)
     assert_kind_of Hash, strategy.raw_info
     assert_equal({}, strategy.raw_info)
   end

--- a/test/test.rb
+++ b/test/test.rb
@@ -16,8 +16,10 @@ class ClientTest < StrategyTestCase
     assert_equal 'https://www.facebook.com/dialog/oauth', strategy.client.options[:authorize_url]
   end
 
-  test 'has correct token url' do
+  test 'has correct token url with versioning' do
+    @options = {:client_options => {:site => 'https://graph.facebook.net/v2.2'}}
     assert_equal 'oauth/access_token', strategy.client.options[:token_url]
+    assert_equal 'https://graph.facebook.net/v2.2/oauth/access_token', strategy.client.token_url
   end
 end
 


### PR DESCRIPTION
Faraday assumes leading slashes are absolute paths, this prevents you from being able to set your version based on the :site. for example when site is "https://graph.facebook.com/v2.2"

https://github.com/lostisland/faraday/issues/293