### PR TITLE
allow the image_size option to be set as a symbol

### DIFF
--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -190,7 +190,7 @@ module OmniAuth
         site_uri = URI.parse(client.site)
         url = uri_class.build({:host => site_uri.host, :path => "#{site_uri.path}/#{uid}/picture"})
 
-        query = if options[:image_size].is_a?(String)
+        query = if options[:image_size].is_a?(String) || options[:image_size].is_a?(Symbol)
           { :type => options[:image_size] }
         elsif options[:image_size].is_a?(Hash)
           options[:image_size]

--- a/test/test.rb
+++ b/test/test.rb
@@ -120,6 +120,13 @@ class InfoTest < StrategyTestCase
     assert_equal 'http://graph.facebook.com/321/picture?type=normal', strategy.info['image']
   end
 
+  test 'returns the image with size specified as a symbol in the `image_size` option' do
+    @options = { :image_size => :normal }
+    raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
+    strategy.stubs(:raw_info).returns(raw_info)
+    assert_equal 'http://graph.facebook.com/321/picture?type=normal', strategy.info['image']
+  end
+
   test 'returns the image with width and height specified in the `image_size` option' do
     @options = { :image_size => { :width => 123, :height => 987 } }
     raw_info = { 'name' => 'Fred Smith', 'id' => '321' }


### PR DESCRIPTION
After upgrading our rails app from omniauth-facebook v1.5.1 to v2.0.0 the `image_size` setting stopped working. We had been setting this option as a symbol instead of as a string which results in no size option actually being set. The resulting image url was `http://graph.facebook.com/id/picture` which is 50x50. 

With this change, the `image_size` option can be set to a symbol.