### PR TITLE
Fix default info_fields to 'name,email'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.1.0 (unreleased)
 
  - Signed request parsing extracted to `OmniAuth::Facebook::SignedRequest` class. (#183, @simi, @Vrael)
+ - Change default value of `info_fields` to `name,email` for the [graph-api-v2.4](https://developers.facebook.com/blog/post/2015/07/08/graph-api-v2.4/). ([#209](https://github.com/mkdynamic/omniauth-facebook/pull/209))
 
 ## 2.0.1 (2015-02-21)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ More details [here](https://github.com/mkdynamic/omniauth-facebook/wiki/CSRF-vul
 
 ---
 
-# OmniAuth Facebook &nbsp;[![Build Status](https://secure.travis-ci.org/mkdynamic/omniauth-facebook.svg?branch=master)](https://travis-ci.org/mkdynamic/omniauth-facebook) [![Gem Version](https://img.shields.io/gem/v/omniauth-facebook.svg)](https://rubygems.org/gems/omniauth-facebook) 
+# OmniAuth Facebook &nbsp;[![Build Status](https://secure.travis-ci.org/mkdynamic/omniauth-facebook.svg?branch=master)](https://travis-ci.org/mkdynamic/omniauth-facebook) [![Gem Version](https://img.shields.io/gem/v/omniauth-facebook.svg)](https://rubygems.org/gems/omniauth-facebook)
 
 
 **These notes are based on master, please see tags for README pertaining to specific releases.**
@@ -45,7 +45,7 @@ Option name | Default | Explanation
 `scope` | `email` | A comma-separated list of permissions you want to request from the user. See the Facebook docs for a full list of available permissions: https://developers.facebook.com/docs/reference/login/
 `display` | `page` | The display context to show the authentication page. Options are: `page`, `popup` and `touch`. Read the Facebook docs for more details: https://developers.facebook.com/docs/reference/dialogs/oauth/
 `image_size` | `square` | Set the size for the returned image url in the auth hash. Valid options include `square` (50x50), `small` (50 pixels wide, variable height), `normal` (100 pixels wide, variable height), or `large` (about 200 pixels wide, variable height). Additionally, you can request a picture of a specific size by setting this option to a hash with `:width` and `:height` as keys. This will return an available profile picture closest to the requested size and requested aspect ratio. If only `:width` or `:height` is specified, we will return a picture whose width or height is closest to the requested size, respectively.
-`info_fields` |  | Specify exactly which fields should be returned when getting the user's info. Value should be a comma-separated string as per https://developers.facebook.com/docs/graph-api/reference/user/ (only `/me` endpoint).
+`info_fields` | 'name,email' | Specify exactly which fields should be returned when getting the user's info. Value should be a comma-separated string as per https://developers.facebook.com/docs/graph-api/reference/user/ (only `/me` endpoint).
 `locale` |  | Specify locale which should be used when getting the user's info. Value should be locale string as per https://developers.facebook.com/docs/reference/api/locale/.
 `auth_type` | | Optionally specifies the requested authentication features as a comma-separated list, as per https://developers.facebook.com/docs/facebook-login/reauthentication/. Valid values are `https` (checks for the presence of the secure cookie and asks for re-authentication if it is not present), and `reauthenticate` (asks the user to re-authenticate unconditionally). Use 'rerequest' when you want to request premissions. Default is `nil`.
 `secure_image_url` | `false` | Set to `true` to use https for the avatar image url returned in the auth hash.
@@ -179,4 +179,3 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/mkdynamic/omniauth-facebook/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
-

--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -60,7 +60,7 @@ module OmniAuth
 
       def info_options
         params = {:appsecret_proof => appsecret_proof}
-        params.merge!({:fields => options[:info_fields]}) if options[:info_fields]
+        params.merge!({:fields => (options[:info_fields] || 'name,email')})
         params.merge!({:locale => options[:locale]}) if options[:locale]
 
         { :params => params }

--- a/test/strategy_test.rb
+++ b/test/strategy_test.rb
@@ -259,7 +259,7 @@ class RawInfoTest < StrategyTestCase
     super
     @access_token = stub('OAuth2::AccessToken')
     @appsecret_proof = 'appsecret_proof'
-    @options = {:appsecret_proof => @appsecret_proof}
+    @options = {:appsecret_proof => @appsecret_proof, :fields => 'name,email'}
   end
 
   test 'performs a GET to https://graph.facebook.com/me' do
@@ -284,6 +284,14 @@ class RawInfoTest < StrategyTestCase
     strategy.stubs(:access_token).returns(@access_token)
     strategy.stubs(:appsecret_proof).returns(@appsecret_proof)
     params = {:params => {:appsecret_proof => @appsecret_proof, :fields => 'about'}}
+    @access_token.expects(:get).with('me', params).returns(stub_everything('OAuth2::Response'))
+    strategy.raw_info
+  end
+
+  test 'performs a GET to https://graph.facebook.com/me with default info_fields' do
+    strategy.stubs(:access_token).returns(@access_token)
+    strategy.stubs(:appsecret_proof).returns(@appsecret_proof)
+    params = {:params => {:appsecret_proof => @appsecret_proof, :fields => 'name,email'}}
     @access_token.expects(:get).with('me', params).returns(stub_everything('OAuth2::Response'))
     strategy.raw_info
   end


### PR DESCRIPTION
## Problem
Version 2.4, default not include the email field.

https://developers.facebook.com/blog/post/2015/07/08/graph-api-v2.4/

> Fewer default fields for faster performance: To help improve performance on mobile network connections, we've reduced the number of fields that the API returns by default. You should now use the ?fields=field1,field2 syntax to declare all the fields you want the API to return.

The default values for 'omni_auth.auth' only `name` and `id` field.

```ruby
"omniauth.auth":{
  "provider":"facebook",
  "uid":"xxxxxx",
  "info":{
    "name":"xxx",
    "image":"http://graph.facebook.com/....."
  },
  "credentials":{
    "token":"...",
    "expires_at":1441880921,
    "expires":true
  },
  "extra":{
    "raw_info": {
      "name":"xxx",
      "id":"xxxxxxxxx"
    }
  }
}
```

## After
**If set the `fields` to only `'email'`, the value of field `name` be set to the email value. So set `fields` to `'name,email'`.**

```ruby
"omniauth.auth":{
  "provider":"facebook",
  "uid":"xxxxxxxxxx",
  "info":{
    "email":"xxxxx@gmail.com",
    "name":"xxx",
    "image":"http://graph.facebook.com/xxxxxxx"
  },
  "credentials":{
    "token":"...",
    "expires_at":1441880921,
    "expires":true
  },
  "extra":{
    "raw_info":{
      "name":"xxx",
      "email":"xxxxxx@gmail.com",
      "id":"xxxxxxxxxx"
    }
  }
}
```