### PR TITLE
add age_range, gender, timezone and locale to info fields fix #234

### DIFF
--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -49,7 +49,8 @@ module OmniAuth
           'gender' => raw_info['gender'],
           'timezone' => raw_info['timezone'],
           'locale' => raw_info['locale'],
-          'birthday' => raw_info['birthday']
+          'birthday' => raw_info['birthday'],
+          'picture' => raw_info['picture']
         })
       end
 

--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -44,7 +44,11 @@ module OmniAuth
             'Website' => raw_info['website']
           },
           'location' => (raw_info['location'] || {})['name'],
-          'verified' => raw_info['verified']
+          'verified' => raw_info['verified'],
+          'age_range' => raw_info['age_range'],
+          'gender' => raw_info['gender'],
+          'timezone' => raw_info['timezone'],
+          'locale' => raw_info['locale']
         })
       end
 

--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -48,7 +48,8 @@ module OmniAuth
           'age_range' => raw_info['age_range'],
           'gender' => raw_info['gender'],
           'timezone' => raw_info['timezone'],
-          'locale' => raw_info['locale']
+          'locale' => raw_info['locale'],
+          'birthday' => raw_info['birthday']
         })
       end
 


### PR DESCRIPTION
Some fields could not be accessed via the info hash even though they were put in the omniauth initializer.