### PR TITLE
Add support to set the redirect_uri on a per-request basis

### DIFF
--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -26,7 +26,7 @@ module OmniAuth
         :param_name => 'access_token'
       }
 
-      option :authorize_options, [:scope, :display, :auth_type]
+      option :authorize_options, [:scope, :display, :auth_type, :redirect_uri]
 
       uid { raw_info['id'] }
 
@@ -98,7 +98,7 @@ module OmniAuth
       # For example: /auth/facebook?display=popup
       def authorize_params
         super.tap do |params|
-          %w[display scope auth_type].each do |v|
+          %w[display scope auth_type redirect_uri].each do |v|
             if request.params[v]
               params[v.to_sym] = request.params[v]
             end

--- a/test/strategy_test.rb
+++ b/test/strategy_test.rb
@@ -60,6 +60,13 @@ class AuthorizeParamsTest < StrategyTestCase
     assert_equal 'touch', strategy.authorize_params[:display]
   end
 
+  test 'includes redirect_uri parameter from request when present' do
+    redirect_uri = 'https://auth.myapp.com/auth/fb/another_callback'
+    @request.stubs(:params).returns({ 'redirect_uri' => redirect_uri })
+    assert strategy.authorize_params.is_a?(Hash)
+    assert_equal redirect_uri, strategy.authorize_params[:redirect_uri]
+  end
+
   test 'includes auth_type parameter from request when present' do
     @request.stubs(:params).returns({ 'auth_type' => 'reauthenticate' })
     assert strategy.authorize_params.is_a?(Hash)


### PR DESCRIPTION
## The problem

I would like to be able to set a different `redirect_uri` for each button, for example:

```ruby
link_to "Fetch my friends", user_omniauth_authorize_path(:facebook, scope: 'user_friends', redirect_uri: 'http://localhost:3000/facebook/fetch_friends')

link_to "Fetch my likes", user_omniauth_authorize_path(:facebook, scope: 'user_likes', redirect_uri: 'http://localhost:3000/facebook/fetch_likes')
```

## The solution

As specified in the [Facebook oauth documentation](https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow), it is possible to pass the `redirect_uri` to the oauth dialog as an URL parameter.

![screen shot 2016-06-13 at 10 39 25 pm](https://cloud.githubusercontent.com/assets/208312/16022414/f50783ae-31b7-11e6-9335-bda091dc2041.png)

Hopefully, this is an interesting improvement for this gem.

Cheers! 🍻 