### PR TITLE
Bump omniauth-oauth2 version to 1.3

### DIFF
--- a/omniauth-facebook.gemspec
+++ b/omniauth-facebook.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.2'
+  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.3'
 
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'mocha'


### PR DESCRIPTION
I am using a number of other Omniauth strategies, some with a dependency on >= 1.3. The previous dependency on 1.2 in this library was causing issues, so I bumped to 1.3.
