### PR TITLE
Bump Facebook Graph to v2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,4 @@ before_install:
 rvm:
   - 2.3.0
   - 2.2
-  - 2.1
-  - 2.0
-  - 1.9.3
-  - jruby-19mode
-  - rbx-2
+  - jruby-9.1.5.0

--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -12,8 +12,8 @@ module OmniAuth
       DEFAULT_SCOPE = 'email'
 
       option :client_options, {
-        site: 'https://graph.facebook.com/v2.6',
-        authorize_url: "https://www.facebook.com/v2.6/dialog/oauth",
+        site: 'https://graph.facebook.com/v2.8',
+        authorize_url: "https://www.facebook.com/v2.8/dialog/oauth",
         token_url: 'oauth/access_token'
       }
 

--- a/test/strategy_test.rb
+++ b/test/strategy_test.rb
@@ -9,11 +9,11 @@ end
 
 class ClientTest < StrategyTestCase
   test 'has correct Facebook site' do
-    assert_equal 'https://graph.facebook.com/v2.6', strategy.client.site
+    assert_equal 'https://graph.facebook.com/v2.8', strategy.client.site
   end
 
   test 'has correct authorize url' do
-    assert_equal 'https://www.facebook.com/v2.6/dialog/oauth', strategy.client.options[:authorize_url]
+    assert_equal 'https://www.facebook.com/v2.8/dialog/oauth', strategy.client.options[:authorize_url]
   end
 
   test 'has correct token url with versioning' do
@@ -99,7 +99,7 @@ class InfoTest < StrategyTestCase
     @options = { secure_image_url: true }
     raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
     strategy.stubs(:raw_info).returns(raw_info)
-    assert_equal 'https://graph.facebook.com/v2.6/321/picture', strategy.info['image']
+    assert_equal 'https://graph.facebook.com/v2.8/321/picture', strategy.info['image']
   end
 
   test 'returns the image_url based of the client site' do
@@ -113,14 +113,14 @@ class InfoTest < StrategyTestCase
     @options = { image_size: 'normal' }
     raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
     strategy.stubs(:raw_info).returns(raw_info)
-    assert_equal 'http://graph.facebook.com/v2.6/321/picture?type=normal', strategy.info['image']
+    assert_equal 'http://graph.facebook.com/v2.8/321/picture?type=normal', strategy.info['image']
   end
 
   test 'returns the image with size specified as a symbol in the `image_size` option' do
     @options = { image_size: :normal }
     raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
     strategy.stubs(:raw_info).returns(raw_info)
-    assert_equal 'http://graph.facebook.com/v2.6/321/picture?type=normal', strategy.info['image']
+    assert_equal 'http://graph.facebook.com/v2.8/321/picture?type=normal', strategy.info['image']
   end
 
   test 'returns the image with width and height specified in the `image_size` option' do
@@ -129,7 +129,7 @@ class InfoTest < StrategyTestCase
     strategy.stubs(:raw_info).returns(raw_info)
     assert_match 'width=123', strategy.info['image']
     assert_match 'height=987', strategy.info['image']
-    assert_match 'http://graph.facebook.com/v2.6/321/picture?', strategy.info['image']
+    assert_match 'http://graph.facebook.com/v2.8/321/picture?', strategy.info['image']
   end
 end
 
@@ -176,7 +176,7 @@ class InfoTestOptionalDataPresent < StrategyTestCase
 
   test 'returns the facebook avatar url' do
     @raw_info['id'] = '321'
-    assert_equal 'http://graph.facebook.com/v2.6/321/picture', strategy.info['image']
+    assert_equal 'http://graph.facebook.com/v2.8/321/picture', strategy.info['image']
   end
 
   test 'returns the Facebook link as the Facebook url' do
@@ -258,7 +258,7 @@ class RawInfoTest < StrategyTestCase
     @options = {appsecret_proof: @appsecret_proof, fields: 'name,email'}
   end
 
-  test 'performs a GET to https://graph.facebook.com/v2.6/me' do
+  test 'performs a GET to https://graph.facebook.com/v2.8/me' do
     strategy.stubs(:appsecret_proof).returns(@appsecret_proof)
     strategy.stubs(:access_token).returns(@access_token)
     params = {params: @options}
@@ -266,7 +266,7 @@ class RawInfoTest < StrategyTestCase
     strategy.raw_info
   end
 
-  test 'performs a GET to https://graph.facebook.com/v2.6/me with locale' do
+  test 'performs a GET to https://graph.facebook.com/v2.8/me with locale' do
     @options.merge!({ locale: 'cs_CZ' })
     strategy.stubs(:access_token).returns(@access_token)
     strategy.stubs(:appsecret_proof).returns(@appsecret_proof)
@@ -275,7 +275,7 @@ class RawInfoTest < StrategyTestCase
     strategy.raw_info
   end
 
-  test 'performs a GET to https://graph.facebook.com/v2.6/me with info_fields' do
+  test 'performs a GET to https://graph.facebook.com/v2.8/me with info_fields' do
     @options.merge!({info_fields: 'about'})
     strategy.stubs(:access_token).returns(@access_token)
     strategy.stubs(:appsecret_proof).returns(@appsecret_proof)
@@ -284,7 +284,7 @@ class RawInfoTest < StrategyTestCase
     strategy.raw_info
   end
 
-  test 'performs a GET to https://graph.facebook.com/v2.6/me with default info_fields' do
+  test 'performs a GET to https://graph.facebook.com/v2.8/me with default info_fields' do
     strategy.stubs(:access_token).returns(@access_token)
     strategy.stubs(:appsecret_proof).returns(@appsecret_proof)
     params = {params: {appsecret_proof: @appsecret_proof, fields: 'name,email'}}


### PR DESCRIPTION
I would normally like to have the latest features with this gem. Graph API v2.6 was recently dropped support for it. Closes #254 

News excerpt from Facebook's Developer Blog:
"Starting 90 days from October 5, 2016, apps using **Graph API v2.7 and below** will _no longer_ be able to create or edit custom action types and object types. One year from October 5, 2016, apps on any version of the API will no longer be able to publish Custom Open Graph stories."
