### PR TITLE
Proposing a PR for going with omniauth-oauth2 v1.3.1

### DIFF
--- a/lib/omniauth/facebook/version.rb
+++ b/lib/omniauth/facebook/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Facebook
-    VERSION = "4.0.0"
+    VERSION = "4.1.0"
   end
 end

--- a/lib/omniauth/facebook/version.rb
+++ b/lib/omniauth/facebook/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Facebook
-    VERSION = "4.1.0"
+    VERSION = "4.0.1"
   end
 end

--- a/omniauth-facebook.gemspec
+++ b/omniauth-facebook.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.2'
+  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.3.1'
 
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'mocha'


### PR DESCRIPTION
Hi,

I needed a version of your omniauth provider for a project of mine, but for dependency reasons, I need to use omniauth-oauth2 in version 1.3.1  (released Jun 2015)
I ran the tests on Travis and the results are the same as they are on current state on your master; so I guess I could propose my 2 lines of commit ;)

I will probably go and propose a version with omniauth-oauth2 in version 1.4 (Released Nov 2015), you never know...

Hope this helps