### PR TITLE
Test only under supported versions of Ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ before_install:
   - gem update --system
   - gem --version
 rvm:
+  - 2.6
   - 2.5
   - 2.4
   - 2.3
-  - 2.2
-  - 2.1
-  - 2.0

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ If you use the server-side flow, Facebook will give you back a longer lived acce
 
 ## Supported Rubies
 
-- Ruby MRI (2.0+)
+- Ruby MRI (2.3, 2.4, 2.5, 2.6)
 
 ## License
 


### PR DESCRIPTION
- Drop testing for Ruby 2.0, 2.1, and 2.2, which are end-of-lifed.
- Add testing for Ruby 2.6.

https://www.ruby-lang.org/en/downloads/branches/

@simi: As a followup to 
https://github.com/mkdynamic/omniauth-facebook/pull/311#issuecomment-453325950 Thank you!