### PR TITLE
Relax omniauth-oauth2 dependency

### DIFF
--- a/omniauth-facebook.gemspec
+++ b/omniauth-facebook.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.2'
+  s.add_runtime_dependency 'omniauth-oauth2', ['>= 1.2', '<= 1.6']
 
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'mocha'


### PR DESCRIPTION
I need this change to be able use other providers. 
The change passes the tests (1.2 - 1.6 individually). 
The fixed version 1.6 works for me in production.